### PR TITLE
third-party.gni: Search includes using -I.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,6 +40,7 @@ Raul Tambre <raul@tambre.ee>
 Samsung <*@samsung.com>
 Samsung Open Source Group <*@osg.samsung.com>
 Sergey Melnikov <Melnikov.Sergey.V@gmail.com>
+Shachar Langbeheim <nihohit@gmail.com>
 Skia <*@skia.org>
 Skia Buildbots <skia.buildbots@gmail.com>
 Sony Mobile Communications Inc. <*@sonymobile.com>

--- a/third_party/third_party.gni
+++ b/third_party/third_party.gni
@@ -24,7 +24,7 @@ template("third_party") {
       } else {
         foreach(dir, invoker.public_include_dirs) {
           cflags += [
-            "-isystem",
+            "-I",
             rebase_path(dir),
           ]
         }


### PR DESCRIPTION
This will ensure that the headers from the dependencies will have
precedent over system headers, thus preventing situations where system
headers will block dependency headers and prevent compilation.

For example, on macOS libjpeg can be read before libjpeg_turbo's
jpeglib.h, and thus block symbols like JCS_EXT_RGBA.